### PR TITLE
Fix missing Color.withValues extension

### DIFF
--- a/lib/adaptive_ui_senior.dart
+++ b/lib/adaptive_ui_senior.dart
@@ -17,6 +17,7 @@ export 'src/themes/high_contrast_theme.dart';
 // Utilities
 export 'src/utils/font_scale_utils.dart';
 export 'src/utils/tap_target_utils.dart';
+export 'src/utils/color_extensions.dart';
 
 // Widgets
 export 'src/widgets/adaptive_text.dart';

--- a/lib/src/themes/high_contrast_theme.dart
+++ b/lib/src/themes/high_contrast_theme.dart
@@ -1,6 +1,7 @@
 // lib/src/themes/high_contrast_theme.dart
 
 import 'package:flutter/material.dart';
+import '../utils/color_extensions.dart';
 
 /// Provides high contrast theme configurations optimized for senior users
 class HighContrastTheme {

--- a/lib/src/utils/color_extensions.dart
+++ b/lib/src/utils/color_extensions.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+/// Extension on [Color] to modify individual channel values.
+/// Primarily used for adjusting the alpha channel while preserving
+/// the other color components.
+extension ColorChannelExtension on Color {
+  /// Returns a copy of this color with the provided channel values replaced.
+  ///
+  /// The [alpha] parameter expects a normalized value in the range 0.0 - 1.0.
+  /// Any value outside this range will be clamped.
+  Color withValues({double? alpha, int? red, int? green, int? blue}) {
+    final int a = ((alpha ?? this.alpha / 255).clamp(0.0, 1.0) * 255).round();
+    return Color.fromARGB(a, red ?? this.red, green ?? this.green, blue ?? this.blue);
+  }
+}

--- a/lib/src/widgets/adaptive_button.dart
+++ b/lib/src/widgets/adaptive_button.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import '../services/accessibility_service.dart';
 import '../utils/tap_target_utils.dart';
+import '../utils/color_extensions.dart';
 import 'adaptive_text.dart';
 import 'helpers/animated_adaptive_constraint.dart';
 


### PR DESCRIPTION
## Summary
- add `ColorChannelExtension.withValues` for adjusting color values
- expose new extension and import it where used

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68449654842883318c6dc54b23a2fa3e